### PR TITLE
Accept entry points in object format

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,11 @@ const resolveRefPackages = (entrypoint) => {
 const tsReferences = {
   name: 'typescript-references',
   setup(build) {
-    const refPackages = build.initialOptions.entryPoints.reduce(
+    // Pull out entry points, which can either be specified as an array or an object with custom output paths
+    // https://esbuild.github.io/api/#entry-points
+    const entryPointOptions = build.initialOptions.entryPoints;
+    const entryPoints = Array.isArray(entryPointOptions) ? entryPointOptions : Object.values(entryPointOptions);
+    const refPackages = entryPoints.reduce(
       (acc, entrypoint) => {
         return Object.assign(acc, resolveRefPackages(entrypoint));
       },

--- a/test/index.js
+++ b/test/index.js
@@ -45,4 +45,17 @@ test('mutiple entries', async () => {
   });
 });
 
+test('mutiple entries with entry points object', async () => {
+  // just make sure there is no exception
+  esbuild.build({
+    entryPoints: {
+      packageA: './test/monorepo/package-a/src/index.ts',
+      packageB: './test/monorepo/package-b/src/index.ts',
+    },
+    bundle: true,
+    outdir: './test/output',
+    plugins: [typescriptReferences],
+  });
+});
+
 test.run();


### PR DESCRIPTION
As outlined in the esbuild docs [here](https://esbuild.github.io/api/#entry-points), `entryPoints` can be specified either as an array, or in "alternative entry point syntax" via an object mapping from output path to entry point. [Currently, only the array format is accepted](https://github.com/smacker/esbuild-plugin-ts-references/blob/cf205033a311428a5b4338b345c3bf465e273f31/index.js#L53), resulting in the error `entryPointOptions.reduce is not a function` being raised when the object form is provided. The change in this PR allows for either array or object entry point format to be used.